### PR TITLE
BUG: Fix VTK file reading and point positions for Slicer

### DIFF
--- a/ScatteredTransform/CMakeLists.txt
+++ b/ScatteredTransform/CMakeLists.txt
@@ -11,6 +11,7 @@ set(MODULE_NAME ScatteredTransform)
 #-----------------------------------------------------------------------------
 set(MODULE_INCLUDE_DIRECTORIES
   ${CMAKE_CURRENT_SOURCE_DIR}
+  ${MRMLCore_INCLUDE_DIRS}
   )
 
 set(MODULE_SRCS
@@ -19,6 +20,7 @@ set(MODULE_SRCS
 
 set(MODULE_TARGET_LIBRARIES
   ${ITK_LIBRARIES}
+  MRMLCore
   )
 
 #-----------------------------------------------------------------------------

--- a/ScatteredTransform/ScatteredTransform.xml
+++ b/ScatteredTransform/ScatteredTransform.xml
@@ -47,13 +47,6 @@
       <default></default>
       <description><![CDATA[File with displaced point positions]]></description>
     </file>
-    <boolean>
-      <name>ignoreFirstValue</name>
-      <longflag>ignoreFirstValue</longflag>
-      <label>   Ignore first value</label>
-      <description>Ignores first value in each line of the input files (which may be a node number).</description>
-      <default>false</default>
-    </boolean>
   </parameters>
   <parameters advanced="false">
     <label>Output transform</label>
@@ -86,15 +79,6 @@
       <element>1D</element>
       <element>2D</element>
       <element>3D</element>
-    </string-enumeration>
-    <string-enumeration>
-      <name>intendedUse</name>
-      <longflag>intendedUse</longflag>
-      <label>   For use in</label>
-      <description>Where is the transform going to be used (only 3D transforms can be used in Slicer)?</description>
-      <default>Slicer</default>
-      <element>ITK</element>
-      <element>Slicer</element>
     </string-enumeration>
     <boolean>
       <name>invertTransform</name>

--- a/ScatteredTransform/Testing/Cxx/CMakeLists.txt
+++ b/ScatteredTransform/Testing/Cxx/CMakeLists.txt
@@ -14,7 +14,7 @@ set_target_properties(${CLP}Test PROPERTIES LABELS ${CLP})
 set(testname ${CLP}Test)
 add_test(NAME ${testname} COMMAND ${SEM_LAUNCH_COMMAND} $<TARGET_FILE:${CLP}Test>
   ModuleEntryPoint
-  --initialPointsFile ${INPUT}/points.csv --displacedPointsFile ${INPUT}/points_disp.csv --ignoreFirstValue 
+  --initialPointsFile ${INPUT}/points.vtp --displacedPointsFile ${INPUT}/points_displaced.vtp
   --bsplineTransformFile ${TEMP}/${CLP}Test.tfm --transformSpaceDimension 3D  
   --invertTransform --useLinearApproximation --splineGridSpacing 100,100,30 --domainFromInputPoints 
   --minCoordinates 0,0,0 --maxCoordinates 100,100,100 --tolerance 0.1 --minGridSpacing 0.1 --maxNumLevels 3 


### PR DESCRIPTION
Point positions were previously read line-by-line without respect for the coordinate system that the file was saved in (LPS/RAS). This commit uses vtkMRMLModelStorageNode to load the points (in RAS), before the points are then converted into LPS.

This removes the need for the IgnoreFirstValue, IntendedUse arguments, as the points should be handled correctly regardless of their intended use.